### PR TITLE
feat(entities/): agregar entidades rol, permiso y permiso_vinculado

### DIFF
--- a/backend/src/entities/permiso.entity.js
+++ b/backend/src/entities/permiso.entity.js
@@ -1,0 +1,34 @@
+import { EntitySchema } from "typeorm";
+
+export const PermisoSchema = new EntitySchema({
+
+    name:'permiso',
+    tableName:"permiso",
+
+    columns: {
+        id_permiso: {
+            type: "int",
+            primary: true,
+            generated: true,
+        },
+        
+        nombre_permiso: {
+            type: "varchar",
+            length: 100,
+            nullable: false,
+        },
+
+        descripcion: {
+            type: "text",
+            nullable: true,
+        },
+    },
+
+    relations: {
+        permisos_vinculados: {
+            type: "one-to-many",
+            target: "permiso_vinculado",
+            inverseSide: "permiso",
+        },
+    },
+})

--- a/backend/src/entities/permiso_vinculado.entity.js
+++ b/backend/src/entities/permiso_vinculado.entity.js
@@ -1,0 +1,47 @@
+import { EntitySchema } from "typeorm";
+
+export const PermisoVinculadoSchema = new EntitySchema({
+    
+    name: 'permiso_vinculado',
+    tableName: "permiso_vinculado",
+
+    columns: {
+        id_rol_permiso: {
+            type: "int",
+            primary: true,
+            generated: true,
+        },
+
+        id_rol: {
+            type: "int",
+            primary: true,
+            generated: true,
+        },
+
+        id_permiso: {
+            type: "int",
+            primary: true,
+            generated: true,
+        },
+    },
+
+    relations: {
+        rol: {
+            type: "many-to-one",
+            target: "rol",
+            joinColumn: { name: "id_rol" },
+            nullable: false,
+            onDelete: "CASCADE",
+            inverseSide: "permisos_vinculados",
+        },
+        permiso: {
+            type: "many-to-one",
+            target: "permiso",
+            joinColumn: { name: "id_permiso" },
+            nullable: false,
+            onDelete: "CASCADE",
+            inverseSide: "permisos_vinculados",
+        },
+    },
+
+});

--- a/backend/src/entities/rol.entity.js
+++ b/backend/src/entities/rol.entity.js
@@ -1,0 +1,34 @@
+import { EntitySchema } from "typeorm";
+
+export const RolSchema = new EntitySchema({
+
+    name:'rol',
+    tableName:"rol",
+
+    columns: {
+        id_rol: {
+            type: "int",
+            primary: true,
+            generated: true,
+        },
+        
+        nombre_rol: {
+            type: "varchar",
+            length: 100,
+            nullable: false,
+        },
+
+        descripcion: {
+            type: "text",
+            nullable: true,
+        },
+    },
+
+    relations: {
+        permisos_vinculados: {
+            type: "one-to-many",
+            target: "permiso_vinculado",
+            inverseSide: "rol",
+        },
+    },
+})


### PR DESCRIPTION
Crear las entidades rol, permiso y permiso_vinculado con sus columnas, claves primarias y relaciones entre roles y permisos usando EntitySchema en TypeORM